### PR TITLE
virtme-prep-kdir-mods: support kernel 6.2

### DIFF
--- a/bin/virtme-prep-kdir-mods
+++ b/bin/virtme-prep-kdir-mods
@@ -24,11 +24,12 @@ ln -srfT . "$MODDIR/build"
 # Remove all preexisting symlinks and add symlinks to all modules that belong
 # to the build kenrnel.
 find "$MODDIR/kernel" -type l -print0 |xargs -0 rm -f --
-while read -r i; do
+# from v6.2, modules.order lists .o files, we need the .ko ones
+sed 's:\.o$:.ko:' modules.order | while read -r i; do
     [ ! -e "$i" ] && i=$(echo "$i" | sed s:^kernel/::)
     mkdir -p "$MODDIR/kernel/$(dirname "$i")"
     ln -sr "$i" "$MODDIR/kernel/$i"
-done < modules.order
+done
 
 
 # Link in the files that make modules_install would copy


### PR DESCRIPTION
Since the kernel commit f65a486821cf ("kbuild: change module.order to list *.o instead of *.ko") that is now in Linus tree in preparation of the future v6.2, module.order file lists .o files instead of .ko ones.

virtme-prep-kdir-mods reads module.order file but it needs to create symlinks for the .ko files, not the .o ones.